### PR TITLE
Remove pore_c suffix from parquet2gr function

### DIFF
--- a/R/chromunity.R
+++ b/R/chromunity.R
@@ -46,10 +46,10 @@ parquet2gr = function(path = NULL, col_names = NULL, save_path = NULL, prefix = 
         stop("Need a valid path to all Pore-C parquets.")
     }
 
-    all.paths = data.table(file_path = dir(path, all.files = TRUE, recursive = TRUE, full = TRUE))[grepl("*pore_c.parquet*", file_path)]
+    all.paths = data.table(file_path = dir(path, all.files = TRUE, recursive = TRUE, full = TRUE))[grepl("*.parquet*", file_path)]
 
     if(nrow(all.paths) == 0){
-        stop("No valid files files with suffix pore_c.parquet found.")
+        stop("No valid files files with suffix .parquet found.")
     } 
 
     if(verbose){"Beginning to read parquet files"}


### PR DESCRIPTION
This simply removes the requirement that parquet files have the suffix "pore_c.parquet", grepping instead for all files with the suffix ".parquet" files as the new epi2me pipeline here does not output files with the pore_c suffix by default. 

https://github.com/epi2me-labs/wf-pore-c